### PR TITLE
회원가입 축하 mail 발송 event 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,9 @@ dependencies {
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
 
+	// email
+	implementation 'org.springframework.boot:spring-boot-starter-mail'
+
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
 
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'

--- a/src/main/java/com/core/accountbook/AccountbookApplication.java
+++ b/src/main/java/com/core/accountbook/AccountbookApplication.java
@@ -1,12 +1,15 @@
 package com.core.accountbook;
 
 import com.core.accountbook.auth.domain.TokenProperties;
+import com.core.accountbook.common.properties.SmtpMailProperties;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.scheduling.annotation.EnableAsync;
 
+@EnableAsync
 @SpringBootApplication
-@EnableConfigurationProperties(TokenProperties.class)
+@EnableConfigurationProperties({TokenProperties.class, SmtpMailProperties.class})
 public class AccountbookApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/core/accountbook/auth/web/MemberAuthController.java
+++ b/src/main/java/com/core/accountbook/auth/web/MemberAuthController.java
@@ -5,10 +5,7 @@ import com.core.accountbook.auth.web.dto.LoginRequest;
 import com.core.accountbook.auth.web.dto.LoginResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Slf4j
 @RestController

--- a/src/main/java/com/core/accountbook/common/event/DomainEvent.java
+++ b/src/main/java/com/core/accountbook/common/event/DomainEvent.java
@@ -1,0 +1,18 @@
+package com.core.accountbook.common.event;
+
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+/**
+ * 이벤트 기본 정보(발생 시점)를 담고 있는 공통 클래스
+ * 구체적인 도메인별 이벤트는 해당 클래스를 상속해 발생 시점 정보를 가지게 됨
+ */
+@Getter
+public class DomainEvent {
+    private final LocalDateTime publishAt;
+
+    public DomainEvent() {
+        this.publishAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/core/accountbook/common/properties/SmtpMailProperties.java
+++ b/src/main/java/com/core/accountbook/common/properties/SmtpMailProperties.java
@@ -1,0 +1,39 @@
+package com.core.accountbook.common.properties;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@ConfigurationProperties(prefix = "spring.mail")
+public class SmtpMailProperties {
+
+    private String host;
+
+    private int port;
+
+    private String username;
+
+    private String password;
+
+    private String encode;
+
+    @Value("${spring.mail.properties.mail.smtp.auth}")
+    private boolean auth;
+
+    @Value("${spring.mail.properties.mail.smtp.timeout}")
+    private int timeout;
+
+    @Value("${spring.mail.properties.mail.smtp.connection-timeout}")
+    private int connectionTimeout;
+
+    @Value("${spring.mail.properties.mail.smtp.starttls.enable}")
+    private boolean starttlsEnable;
+
+    @Value("${spring.mail.properties.mail.smtp.starttls.required}")
+    private boolean starttlsRequired;
+
+}

--- a/src/main/java/com/core/accountbook/common/response/ResultResponseAdvice.java
+++ b/src/main/java/com/core/accountbook/common/response/ResultResponseAdvice.java
@@ -4,7 +4,6 @@ import com.core.accountbook.common.exception.ErrorCode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.MethodParameter;
 import org.springframework.http.MediaType;
 import org.springframework.http.converter.HttpMessageConverter;

--- a/src/main/java/com/core/accountbook/config/MailConfig.java
+++ b/src/main/java/com/core/accountbook/config/MailConfig.java
@@ -1,0 +1,47 @@
+package com.core.accountbook.config;
+
+import com.core.accountbook.common.properties.SmtpMailProperties;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+
+import java.util.Properties;
+
+/**
+ * mailSender 사용을 위한 기본 프로퍼티 구성 클래스
+ */
+@Slf4j
+@Configuration
+@RequiredArgsConstructor
+public class MailConfig {
+
+    private final SmtpMailProperties smtpMailProperties;
+
+    @Bean
+    public JavaMailSender javaMailSender() {
+        JavaMailSenderImpl mailSender = new JavaMailSenderImpl();
+        mailSender.setHost(smtpMailProperties.getHost());
+        mailSender.setPort(smtpMailProperties.getPort());
+        mailSender.setUsername(smtpMailProperties.getUsername());
+        mailSender.setPassword(smtpMailProperties.getPassword());
+        mailSender.setDefaultEncoding(smtpMailProperties.getEncode());
+        mailSender.setJavaMailProperties(getProperties());
+        mailSender.getJavaMailProperties();
+
+        return mailSender;
+    }
+
+    private Properties getProperties() {
+        Properties properties = new Properties();
+        properties.put("mail.smtp.auth", smtpMailProperties.isAuth());
+        properties.put("mail.smtp.starttls.enable", smtpMailProperties.isStarttlsEnable());
+        properties.put("mail.smtp.starttls.required", smtpMailProperties.isStarttlsRequired());
+        properties.put("mail.smtp.connection-timeout", smtpMailProperties.getConnectionTimeout());
+        properties.put("mail.smtp.timeout", smtpMailProperties.getTimeout());
+
+        return properties;
+    }
+}

--- a/src/main/java/com/core/accountbook/email/event/MemberRegisterEvent.java
+++ b/src/main/java/com/core/accountbook/email/event/MemberRegisterEvent.java
@@ -1,0 +1,12 @@
+package com.core.accountbook.email.event;
+
+import com.core.accountbook.common.event.DomainEvent;
+import com.core.accountbook.member.domain.Member;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class MemberRegisterEvent extends DomainEvent {
+    private final Member member;
+}

--- a/src/main/java/com/core/accountbook/email/event/handler/MemberRegisterEmailHandler.java
+++ b/src/main/java/com/core/accountbook/email/event/handler/MemberRegisterEmailHandler.java
@@ -1,0 +1,36 @@
+package com.core.accountbook.email.event.handler;
+
+import com.core.accountbook.email.event.MemberRegisterEvent;
+import com.core.accountbook.email.service.EmailService;
+import com.core.accountbook.member.domain.Member;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+/**
+ * 발행된 이벤트를 구독해 내부 로직을 처리하는 책임을 가진 클래스
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class MemberRegisterEmailHandler {
+
+    private final EmailService emailService;
+
+    @Async
+    @TransactionalEventListener(
+            classes = MemberRegisterEvent.class,
+            phase = TransactionPhase.AFTER_COMMIT
+    )
+    public void handleEvent(MemberRegisterEvent memberRegisterEvent) {
+        log.info("이벤트 핸들링 시작 - {}", this.getClass().getSimpleName());
+
+        Member member = memberRegisterEvent.getMember();
+        emailService.sendEmail(member.getEmail(), member.getName());
+
+        log.info("이벤트 핸들링 종료 - {}", this.getClass().getSimpleName());
+    }
+}

--- a/src/main/java/com/core/accountbook/email/event/publisher/MemberRegisterEmailPublisher.java
+++ b/src/main/java/com/core/accountbook/email/event/publisher/MemberRegisterEmailPublisher.java
@@ -1,0 +1,32 @@
+package com.core.accountbook.email.event.publisher;
+
+import com.core.accountbook.email.event.MemberRegisterEvent;
+import com.core.accountbook.member.domain.Member;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.ApplicationEventPublisherAware;
+import org.springframework.stereotype.Component;
+
+/**
+ * 회원가입 축하 email 발송 이벤트 발행 책임을 가지는 클래스
+ */
+@Slf4j
+@Component
+public class MemberRegisterEmailPublisher implements ApplicationEventPublisherAware {
+
+    private static ApplicationEventPublisher applicationEventPublisher;
+
+
+    public static void publishEvent(final Member member) {
+        log.info("이벤트 발행 시작 - MemberRegisterEmailPublisher");
+        MemberRegisterEvent event = new MemberRegisterEvent(member);
+
+        applicationEventPublisher.publishEvent(event);
+        log.info("이벤트 발행 종료 - MemberRegisterEmailPublisher");
+    }
+
+    @Override
+    public void setApplicationEventPublisher(ApplicationEventPublisher applicationEventPublisher) {
+        MemberRegisterEmailPublisher.applicationEventPublisher = applicationEventPublisher;
+    }
+}

--- a/src/main/java/com/core/accountbook/email/service/EmailService.java
+++ b/src/main/java/com/core/accountbook/email/service/EmailService.java
@@ -1,0 +1,50 @@
+package com.core.accountbook.email.service;
+
+import com.core.accountbook.member.domain.repository.MemberRepository;
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class EmailService {
+
+    private final JavaMailSender mailSender;
+    private final MemberRepository memberRepository;
+
+    public void sendEmail(String email, String name) {
+        MimeMessage mimeMessage = mailSender.createMimeMessage();
+
+        try {
+            MimeMessageHelper mimeMessageHelper = new MimeMessageHelper(mimeMessage, false, "UTF-8");
+            mimeMessageHelper.setTo(email); // 메일 수신자
+            mimeMessageHelper.setSubject(name + "님의 가계부 회원가입을 축하합니다!"); // 메일 제목
+
+            // HTML 템플릿 로딩
+            String htmlContent = loadTemplate("templates/welcome-email-form.html")
+                    .replace("{{name}}", name);
+
+            mimeMessageHelper.setText(htmlContent, true); // 메일 본문 내용, HTML 여부
+
+            mailSender.send(mimeMessage);
+        } catch (MessagingException e) {
+            log.error(e.getMessage());
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private String loadTemplate(String path) throws IOException {
+        return new String(Files.readAllBytes(Paths.get(new ClassPathResource(path).getURI())));
+    }
+}

--- a/src/main/java/com/core/accountbook/member/application/MemberCommandService.java
+++ b/src/main/java/com/core/accountbook/member/application/MemberCommandService.java
@@ -9,6 +9,7 @@ import com.core.accountbook.member.exception.MemberException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Service
@@ -18,6 +19,7 @@ public class MemberCommandService {
     private final MemberRepository memberRepository;
     private final PasswordEncryptor passwordEncoder;
 
+    @Transactional
     public void signUp(SignUpServiceRequest request) {
 
         validateDuplicateEmail(request.getEmail());

--- a/src/main/java/com/core/accountbook/member/domain/Member.java
+++ b/src/main/java/com/core/accountbook/member/domain/Member.java
@@ -1,6 +1,7 @@
 package com.core.accountbook.member.domain;
 
 import com.core.accountbook.common.entity.BaseEntity;
+import com.core.accountbook.email.event.publisher.MemberRegisterEmailPublisher;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -62,6 +63,11 @@ public class Member extends BaseEntity {
         this.loginType = loginType;
         this.emailVerified = emailVerified;
         this.lockCount = lockCount;
+    }
+
+    @PostPersist
+    private void registerEvent() {
+        MemberRegisterEmailPublisher.publishEvent(this);
     }
 
     public Password toPassword(String password) {

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -22,9 +22,26 @@ spring:
         default_batch_fetch_size: 50
         format_sql: true
 
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: username
+    password: password
+    default-encoding: UTF-8
+    properties:
+      mail:
+        smtp:
+          auth: true
+          timeout: 5000
+          connection-timeout: 5000
+          starttls:
+            enable: true
+            required: true
+
 access-token:
   secret-key: 1234567890123456789012345678901212345678901234567890123456789012
   expire-length: 12345
 
 refresh-token:
   expire-length: 12345
+

--- a/src/main/resources/templates/welcome-email-form.html
+++ b/src/main/resources/templates/welcome-email-form.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8">
+  <title>회원가입 축하</title>
+</head>
+<body style="font-family: Arial, sans-serif; background-color: #f4f4f4; margin: 0; padding: 20px;">
+<div style="background-color: #ffffff; margin: 0 auto; padding: 20px; border-radius: 8px; box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1); max-width: 600px;">
+  <h1 style="color: #4CAF50; text-align: center;">가계부 회원가입을 축하합니다!</h1>
+  <br>
+  <br>
+  <div class="centered-text" style="text-align: center;">
+    <p>안녕하세요, <strong>{{name}}</strong>님,</p>
+    <p>저희 서비스에 가입해주셔서 감사합니다✨</p>
+    <p>가계부에서 제공하는 다양한 다양한 서비스를 마음껏 이용 부탁드릴게요~!😊</p>
+    <p>궁금한 점이 있으시면 언제든지 문의해 주세요!</p>
+    <p>가계부팀 드림📜</p>
+  </div>
+</div>
+</body>
+</html>


### PR DESCRIPTION
## 📝작업 내용
> Email Util 클래스 구현
> 이벤트 객체 생성 및 이벤트 publisher, handler(listener) 구현
> 회원가입 완료 시점에 맞춘 event publishing 기능 구현
> 축하 mail 발송 event 비동기(Async) 처리 

## #️⃣연관된 이슈
> closed : #9 

## 💬리뷰 요구 및 추가 사항(선택)
```java
@Async
    @TransactionalEventListener(
            classes = MemberRegisterEvent.class,
            phase = TransactionPhase.AFTER_COMMIT
    )
    public void handleEvent(MemberRegisterEvent memberRegisterEvent) {
        log.info("이벤트 핸들링 시작 - {}", this.getClass().getSimpleName());

        Member member = memberRegisterEvent.getMember();
        emailService.sendEmail(member.getEmail(), member.getName());

        log.info("이벤트 핸들링 종료 - {}", this.getClass().getSimpleName());
    }
```
signUp의 트랜잭션 상태에 따라 이벤트 구독 & 처리 여부를 제어하기 위해 `@TransactionalEventListener` 사용
- signUp 메서드 commit 완료 시점에 event 실행하기 위해 phase = TransactionPhase.AFTER_COMMIT 적용
- signUp commit -> event 처리 / signUp rollback -> 이벤트 미처리 
- email 로직 에러 발생 -> signUp 메서드 정상 실행 : signUp 로직과 email 발송 로직간의 결합도를 감소시킴
- - @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT) 사용으로 이벤트 로직은 메인 로직 완료 여부에 의존하며 메인 로직은 이벤트 처리 로직에 의존하지 않도록 관계 개선 (트랜잭션 분리)

비동기(Async) 이벤트 처리를 통한 회원가입 처리 속도 개선
- signUp 로직의 처리 완료 시점이 이벤트 처리 완료 시점에 결합되는 issue 발생(스프링 이벤트는 기본적으로 같은 스레드에서 실행됨)
- @Async 어노테이션 사용해 이벤트 비동기 처리
- 회원가입 완료와 이벤트 완료를 비동기 이벤트 처리로 인해 분리

![image](https://github.com/user-attachments/assets/cd5d192b-149e-4770-baba-77bafcdd24bc)
이벤트 처리 개선 전

![image](https://github.com/user-attachments/assets/32ee134c-d51d-46d9-9aa5-9212199a9f4f)
이벤트 처리 개선 후
- 회원가입 처리 속도 4500ms~5400ms -> 200ms ~ 300ms 개선

TODO
- 하나의 이벤트만을 사용하고 있기에 여러 이벤트 발생 시 비동기 설정의 한단계 높은 추상화 방안 및 트랜잭션 관계 개선 방안 고려 필요
- 이벤트 처리 로직이 늘어날수록 공통 코드를 추상화할 방안 고려 필요


